### PR TITLE
feat: Add unit tests, roadmap, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
-# portfolio-snooper
+# Fund Ownership Analyzer
+
+## Description
+
+The Fund Ownership Analyzer is a Python application designed to provide insights into the holdings of mutual funds and ETFs. It fetches data from SEC EDGAR filings to determine a fund's holdings and then uses the Alpha Vantage API to gather information about the underlying companies, including calculating the approximate percentage of a company's stock owned by the analyzed fund. The results are delivered as a formatted report via email using the Gmail API.
+
+## Features
+
+*   Retrieves and parses NPORT-P (and N-Q as fallback) filings from SEC EDGAR.
+*   Extracts detailed fund holdings: stock name, CUSIP, ticker, market value, shares, and percentage of fund assets.
+*   Fetches total outstanding shares for each holding using Alpha Vantage API.
+*   Calculates the percentage of each underlying company owned by the fund.
+*   Generates a text-based report summarizing the analysis.
+*   Sends the report to a specified email address using the Gmail API (requires user authentication via OAuth 2.0).
+*   Command-Line Interface (CLI) for easy operation.
+*   Handles API rate limits and missing data gracefully.
+
+## Prerequisites
+
+*   Python 3.7+
+*   `pip` (Python package installer)
+*   Access to a Gmail account (for sending email reports).
+*   An Alpha Vantage API Key.
+*   Google Cloud Project for Gmail API access.
+
+## Setup Instructions
+
+1.  **Clone the Repository (if applicable) or Download Files:**
+    Ensure you have all the project files (`main.py`, `fund_analyzer.py`, `sec_parser.py`, `report_generator.py`, `requirements.txt`) in a single directory.
+
+2.  **Create a Virtual Environment (Recommended):**
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+
+3.  **Install Dependencies:**
+    Navigate to the project directory in your terminal and run:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+4.  **Set up Alpha Vantage API Key:**
+    *   Visit [Alpha Vantage](https://www.alphavantage.co/support/#api-key) to obtain a free API key.
+    *   You can set this key as an environment variable named `ALPHA_VANTAGE_API_KEY`.
+        *   On Linux/macOS: `export ALPHA_VANTAGE_API_KEY="YOUR_KEY_HERE"` (add to your `.bashrc` or `.zshrc` for persistence).
+        *   On Windows: `set ALPHA_VANTAGE_API_KEY="YOUR_KEY_HERE"` (in Command Prompt) or `$env:ALPHA_VANTAGE_API_KEY="YOUR_KEY_HERE"` (in PowerShell).
+    *   Alternatively, you can create a `.env` file in the project root directory with the line:
+        `ALPHA_VANTAGE_API_KEY="YOUR_KEY_HERE"`
+    *   You can also provide the key directly via the `--alpha_vantage_key` CLI argument when running the application.
+    *   **Note:** The free Alpha Vantage 'demo' key is heavily restricted and may only work for fetching data for the 'IBM' ticker or quickly hit rate limits. A personal free key is recommended for better results.
+
+5.  **Set up Gmail API Credentials:**
+    This is required to allow the application to send emails on your behalf.
+    *   Go to the [Google Cloud Console](https://console.cloud.google.com/).
+    *   Create a new project (or select an existing one).
+    *   Enable the **Gmail API** for your project.
+        *   Search for "Gmail API" in the marketplace or API library and enable it.
+    *   Create OAuth 2.0 Client ID credentials:
+        *   Go to "Credentials" in the APIs & Services section.
+        *   Click "Create Credentials" -> "OAuth client ID".
+        *   If prompted, configure the OAuth consent screen (User Type: External, provide app name, user support email, developer contact). For scopes, you can leave it blank for now or add `../auth/gmail.send` if prompted during consent screen setup.
+        *   Select "Desktop app" as the Application type.
+        *   Give it a name (e.g., "Fund Analyzer CLI").
+        *   Click "Create".
+    *   Download the credentials JSON file. It will likely be named `client_secret_XXXXXXXX.json`. **Rename this file to `credentials.json` and place it in the root directory of this project.**
+
+    **Important:** The first time you run the application and it attempts to send an email, a browser window will open asking you to log in to your Google account and grant the application permission to send emails. After successful authorization, a `token.json` file will be created in the project directory to store your authorization tokens for future use.
+
+## Usage
+
+The application is run from the command line using `main.py`.
+
+**Command-Line Arguments:**
+
+*   `--fund FUND_IDENTIFIER`: (Required) The ticker symbol or name of the mutual fund/ETF to analyze (e.g., "VFINX", "SPY"). Note: CIK resolution from name/ticker is currently basic.
+*   `--email RECIPIENT_EMAIL`: (Required) The email address where the analysis report will be sent.
+*   `--alpha_vantage_key YOUR_API_KEY`: (Optional) Your Alpha Vantage API key. If not provided, it will try to use the `ALPHA_VANTAGE_API_KEY` environment variable, then default to 'demo'.
+
+**Example Command:**
+
+```bash
+python main.py --fund "VFINX" --email "your_email@example.com"
+```
+
+Or, if you have your Alpha Vantage key in the environment:
+
+```bash
+python main.py --fund "SPY" --email "your_email@example.com"
+```
+
+To use a specific Alpha Vantage key via CLI:
+```bash
+python main.py --fund "VTSAX" --email "another_email@example.com" --alpha_vantage_key "YOUR_ACTUAL_AV_KEY"
+```
+
+**First Run (Gmail Authentication):**
+When you run a command that triggers email sending for the first time (or if `token.json` is invalid/deleted), your web browser should open. You'll need to:
+1.  Choose the Google account associated with the `credentials.json` you set up.
+2.  If you see a "Google hasn’t verified this app" screen, click "Advanced" and then "Go to [Your App Name] (unsafe)". This is expected for local test applications that haven't gone through Google's formal verification process.
+3.  Grant the application permission to "Send email on your behalf".
+4.  The browser will confirm, and you can close the tab. The application will then proceed to send the email. A `token.json` file will be saved in your project directory.
+
+## Project File Structure
+
+*   `main.py`: CLI entry point for the application.
+*   `fund_analyzer.py`: Core logic for orchestrating fund analysis, including calls to SEC parser and Alpha Vantage.
+*   `sec_parser.py`: Handles downloading and parsing SEC EDGAR filings (NPORT-P, N-Q).
+*   `report_generator.py`: Formats the analysis data into an email report and handles Gmail API interaction.
+*   `requirements.txt`: Lists Python package dependencies.
+*   `tests/`: Directory containing unit tests.
+    *   `test_sec_parser.py`
+    *   `test_fund_analyzer.py`
+    *   `test_report_generator.py`
+*   `roadmap.md`: Outlines potential future enhancements for the application.
+*   `.env` (optional, if created by user): For storing `ALPHA_VANTAGE_API_KEY`.
+*   `credentials.json` (user-provided): OAuth 2.0 client credentials for Gmail API.
+*   `token.json` (generated): Stores user's Gmail API access/refresh tokens after successful OAuth.
+
+## Running Unit Tests
+
+To run the unit tests, navigate to the project's root directory and execute:
+
+```bash
+python -m unittest discover tests
+```
+
+To run a specific test file:
+```bash
+python -m unittest tests.test_sec_parser
+```
+
+## Current Limitations
+
+*   **CIK Resolution:** The current mechanism for resolving a fund ticker/name to an SEC CIK is a basic placeholder. For reliable analysis of various funds, this needs to be made more robust.
+*   **Alpha Vantage Demo Key:** The 'demo' key for Alpha Vantage is severely rate-limited and often only supports fetching detailed company overview data for the 'IBM' ticker. A personal free key from Alpha Vantage is highly recommended.
+*   **Ticker Availability:** NPORT-P filings do not always contain explicit ticker symbols for all holdings (CUSIP is more common). The application currently prioritizes holdings with tickers for Alpha Vantage lookups. A CUSIP-to-ticker mapping could enhance this.
+*   **SEC Edgar Data Availability:** The `sec-edgar-downloader` library relies on specific SEC data URLs. If these change or are unavailable for certain CIKs, downloading may fail.
+
+## Future Development
+
+See the `roadmap.md` file for a list of planned and potential future enhancements.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,63 @@
+# Application Roadmap: Fund Ownership Analyzer
+
+This document outlines potential future enhancements and new areas of analysis for the Fund Ownership Analyzer application.
+
+## Core Functionality Enhancements
+
+*   **Robust CIK Resolution:**
+    *   Implement a more reliable method to resolve fund tickers/names to the correct CIK that contains NPORT-P (or other relevant) filings. This could involve searching SEC EDGAR more programmatically or using a dedicated mapping API.
+*   **CUSIP to Ticker Mapping:**
+    *   For holdings where NPORT-P filings primarily provide CUSIPs, develop a robust mechanism to map CUSIPs to ticker symbols. This is crucial for fetching data from APIs like Alpha Vantage that often rely on tickers.
+*   **Improved Handling of Different Share Classes:**
+    *   Enhance logic to differentiate and correctly aggregate holdings across various share classes of the same underlying company.
+*   **Historical Data Analysis:**
+    *   Allow users to specify a date or date range to analyze fund holdings as of that period, not just the latest filings. This would involve modifications to the SEC filing download logic.
+*   **Configuration File:**
+    *   Allow users to set default parameters (e.g., recipient email, preferred funds, API keys if not using env vars) in a user-specific configuration file (`config.ini` or `config.yaml`).
+*   **Enhanced Error Handling & Logging:**
+    *   Implement more granular error messages for users.
+    *   Add comprehensive logging throughout the application lifecycle for easier debugging and tracing of issues.
+*   **Expanded Output Formats:**
+    *   Provide options to output the analysis data in formats like CSV or JSON, in addition to the email report. This would make the data more accessible for other tools or analyses.
+
+## New Areas of Analysis
+
+*   **Institutional Holdings (13F Filings):**
+    *   Incorporate analysis of Form 13F filings to track holdings of large institutional investment managers. This would provide a broader view of institutional ownership beyond individual mutual funds.
+*   **Beneficial Ownership (Schedule 13D/13G, Form 4):**
+    *   **Registered Individual Ownership:** Investigate and implement methods to analyze beneficial ownership by individuals and significant shareholders as reported in Schedule 13D, 13G, and Form 4 filings. This is a complex but highly valuable area.
+*   **Company-Centric Analysis (10-K/10-Q Reports):**
+    *   Expand beyond fund analysis to extract and analyze data from company annual (10-K) and quarterly (10-Q) reports. This could include:
+        *   Detailed financial statement analysis.
+        *   Extraction of risk factors.
+        *   Management's Discussion and Analysis (MD&A) insights.
+        *   Executive compensation.
+*   **Private Placement Analysis (Form D):**
+    *   Analyze Form D filings to gather information on private placements and exempt securities offerings.
+*   **Portfolio Overlap Analysis:**
+    *   Given a list of multiple funds or institutional managers, identify common stock holdings and quantify the degree of portfolio overlap.
+*   **Sector and Industry Allocation Analysis:**
+    *   From fund holdings, determine and report on the allocation across different economic sectors and industries. This might require mapping holdings to industry classifications (e.g., GICS).
+
+## User Interface & Experience
+
+*   **Web Interface:**
+    *   Develop a simple web interface (e.g., using Flask or Django) as an alternative or complement to the existing CLI, allowing for easier input and visualization of results.
+*   **Interactive Data Visualization:**
+    *   Integrate with charting libraries (e.g., Matplotlib, Seaborn, Plotly) to generate visual representations of the analysis (e.g., top holdings, ownership distribution) within the email report or a web interface.
+*   **Improved User Prompts for Gmail Auth:**
+    *   Make the initial Gmail OAuth process more user-friendly with clearer instructions if `credentials.json` is missing or `token.json` needs refreshing.
+
+## Technical & Development Enhancements
+
+*   **Comprehensive Unit & Integration Testing:**
+    *   Continue to expand unit test coverage for all modules.
+    *   Implement integration tests to verify the end-to-end workflow.
+*   **Asynchronous Operations:**
+    *   For fetching data from multiple sources (e.g., Alpha Vantage calls for many holdings), explore asynchronous operations (`asyncio`) to improve performance.
+*   **Database Integration:**
+    *   Optionally, allow storing fetched and parsed data in a local database (e.g., SQLite) for caching, historical analysis, and more complex queries.
+*   **Plugin Architecture:**
+    *   Consider a plugin architecture to more easily add new data sources or analysis modules in the future.
+
+This roadmap is intended to be dynamic and will evolve based on user feedback and development priorities.

--- a/tests/test_fund_analyzer.py
+++ b/tests/test_fund_analyzer.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import fund_analyzer
+
+class TestFundAnalyzer(unittest.TestCase):
+
+    @patch('fund_analyzer.sec_parser.download_latest_fund_holding_filing')
+    @patch('fund_analyzer.sec_parser.parse_nport_xml_filing')
+    @patch('fund_analyzer.get_company_shares_outstanding') # Mocks the function within fund_analyzer
+    def test_analyze_fund_ownership_success(self, mock_get_shares, mock_parse_nport, mock_download_filing):
+        # Setup mocks
+        mock_download_filing.return_value = "/fake/path/to/filings/0001234567/NPORT-P"
+        mock_parse_nport.return_value = (
+            "Test Fund X",
+            100000000.0,
+            [
+                {'name': 'Company A', 'cusip': 'CUSIPA', 'ticker': 'CMPA', 'shares_or_principal_amount': '100', 'market_value_usd': 10000.0, 'percentage_of_fund': 0.01},
+                {'name': 'Company B (No Ticker)', 'cusip': 'CUSIPB', 'ticker': None, 'shares_or_principal_amount': '200', 'market_value_usd': 20000.0, 'percentage_of_fund': 0.02},
+                {'name': 'Company C Bond', 'cusip': 'CUSIPC', 'ticker': 'CMPCT', 'shares_or_principal_amount': '30000', 'market_value_usd': 30000.0, 'percentage_of_fund': 0.03} # Shares might be principal for bond
+            ]
+        )
+        # Mock return for shares outstanding: first call for CMPA, second for CMPCT (if it were equity)
+        mock_get_shares.side_effect = [1000000, 5000000]
+
+        # Ensure API_KEY is not 'demo' for this test to allow processing all holdings
+        # Also, ensure that fund_analyzer.API_KEY is updated if it's checked at module load time
+        # or if analyze_fund_ownership re-reads it.
+        with patch.dict(os.environ, {'ALPHA_VANTAGE_API_KEY': 'fakekey_for_test'}):
+            # If fund_analyzer.API_KEY is set at module load, we need to patch it or reload the module.
+            # A simpler approach for testing is to ensure its functions can be influenced by a passed-in key
+            # or it re-evaluates os.getenv. The current fund_analyzer.py re-evaluates os.getenv in analyze_fund_ownership.
+            fund_analyzer.API_KEY = 'fakekey_for_test' # Directly set for this test context if needed by other functions
+            fund_analyzer.CALL_DELAY_SECONDS = 0 # No delay in tests
+
+            result = fund_analyzer.analyze_fund_ownership("VFINX_TEST") # Fund ticker
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result['status'], "Analysis complete.")
+            self.assertEqual(result['fund_name'], "Test Fund X")
+            self.assertEqual(result['total_net_assets'], 100000000.0)
+            self.assertEqual(len(result['detailed_holdings']), 3)
+
+            # Check Company A (CMPA)
+            self.assertEqual(result['detailed_holdings'][0]['name'], 'Company A')
+            self.assertEqual(result['detailed_holdings'][0]['total_outstanding_shares'], 1000000)
+            self.assertAlmostEqual(result['detailed_holdings'][0]['percentage_of_company_owned_by_fund'], (100 / 1000000) * 100)
+
+            # Check Company B (No Ticker) - should not have ownership calculated
+            self.assertEqual(result['detailed_holdings'][1]['name'], 'Company B (No Ticker)')
+            self.assertEqual(result['detailed_holdings'][1]['percentage_of_company_owned_by_fund'], "N/A (No Ticker/Shares)")
+
+            # Check Company C (CMPCT) - assume shares_held_by_fund_num would be float(30000)
+            self.assertEqual(result['detailed_holdings'][2]['name'], 'Company C Bond')
+            self.assertEqual(result['detailed_holdings'][2]['total_outstanding_shares'], 5000000)
+            self.assertAlmostEqual(result['detailed_holdings'][2]['percentage_of_company_owned_by_fund'], (30000 / 5000000) * 100)
+
+            mock_download_filing.assert_called_once()
+            mock_parse_nport.assert_called_once()
+            self.assertEqual(mock_get_shares.call_count, 2) # Called for CMPA and CMPCT
+
+    @patch('alpha_vantage.fundamentaldata.FundamentalData.get_company_overview')
+    def test_get_company_shares_outstanding_success(self, mock_get_overview):
+        mock_get_overview.return_value = ({'SharesOutstanding': '123456789'}, None)
+        # Temporarily set API_KEY for this test to non-demo to bypass demo key specific logic
+        original_api_key = fund_analyzer.API_KEY
+        fund_analyzer.API_KEY = 'fake_test_key'
+        try:
+            shares = fund_analyzer.get_company_shares_outstanding("TESTTICKER")
+            self.assertEqual(shares, 123456789)
+        finally:
+            fund_analyzer.API_KEY = original_api_key # Reset
+
+    @patch('alpha_vantage.fundamentaldata.FundamentalData.get_company_overview')
+    def test_get_company_shares_outstanding_api_failure(self, mock_get_overview):
+        mock_get_overview.side_effect = Exception("API Error")
+        original_api_key = fund_analyzer.API_KEY
+        fund_analyzer.API_KEY = 'fake_test_key'
+        try:
+            shares = fund_analyzer.get_company_shares_outstanding("TESTTICKER")
+            self.assertIsNone(shares)
+        finally:
+            fund_analyzer.API_KEY = original_api_key
+
+    def test_resolve_fund_ticker_to_cik(self):
+        self.assertEqual(fund_analyzer.resolve_fund_ticker_to_cik("VFINX"), "0000036405")
+        self.assertIsNone(fund_analyzer.resolve_fund_ticker_to_cik("UNKNOWNTICKER"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import report_generator
+
+class TestReportGenerator(unittest.TestCase):
+
+    def test_format_data_for_email_success(self):
+        analysis_result = {
+            "fund_cik": "000TESTCIK",
+            "fund_name": "Test Fund Alpha",
+            "fund_ticker": "TFA",
+            "total_net_assets": 123456789.00,
+            "holdings_count": 1,
+            "holdings_processed_for_company_ownership": 1,
+            "detailed_holdings": [
+                {
+                    'name': 'Test Company XYZ', 'cusip': 'TESTCUSIP1', 'ticker': 'XYZ',
+                    'market_value_in_fund': 1234567.0, 'percentage_of_fund': 0.01,
+                    'shares_held_by_fund_str': '10000',
+                    'total_outstanding_shares': 100000000,
+                    'percentage_of_company_owned_by_fund': 0.01
+                }
+            ],
+            "status": "Analysis complete."
+        }
+        report = report_generator.format_data_for_email(analysis_result)
+        self.assertIn("Fund Name: Test Fund Alpha", report)
+        self.assertIn("Fund CIK: 000TESTCIK", report)
+        self.assertIn("Total Net Assets: $123,456,789.00", report)
+        self.assertIn("Name: Test Company XYZ", report)
+        self.assertIn("Percentage of Company Owned by Fund: 0.010000%", report)
+
+    def test_format_data_for_email_failure_status(self):
+        analysis_result = {"status": "Download failed.", "fund_cik": "000FAIL"}
+        report = report_generator.format_data_for_email(analysis_result)
+        self.assertIn("Fund analysis could not be completed.", report)
+        self.assertIn("Status: Download failed.", report)
+
+    @patch('report_generator.gmail_authenticate')
+    @patch('report_generator.build')
+    def test_send_email_report_success(self, mock_build, mock_gmail_authenticate):
+        # Mock successful authentication and email sending
+        mock_creds = MagicMock()
+        mock_gmail_authenticate.return_value = mock_creds
+
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+        mock_send_message_response = {'id': 'test_message_id'}
+        mock_service.users.return_value.messages.return_value.send.return_value.execute.return_value = mock_send_message_response
+
+        success = report_generator.send_email_report("test@example.com", "Test Subject", "Test Body")
+
+        self.assertTrue(success)
+        mock_gmail_authenticate.assert_called_once()
+        mock_build.assert_called_once_with('gmail', 'v1', credentials=mock_creds)
+        mock_service.users.return_value.messages.return_value.send.assert_called_once()
+
+    @patch('report_generator.gmail_authenticate', return_value=None) # Simulate auth failure
+    def test_send_email_report_auth_failure(self, mock_gmail_authenticate):
+        success = report_generator.send_email_report("test@example.com", "Test Subject", "Test Body")
+        self.assertFalse(success)
+        mock_gmail_authenticate.assert_called_once()
+
+    # Test for gmail_authenticate would be more complex due to file I/O and OAuth flow
+    # For now, we focus on testing send_email_report assuming gmail_authenticate works or is mocked.
+    # A simple test for credentials_file not found:
+    @patch('report_generator.os.path.exists')
+    def test_gmail_authenticate_no_credentials_file(self, mock_os_exists):
+        # Simulate token.json not existing, then credentials.json not existing
+        mock_os_exists.side_effect = [False, False]
+        creds = report_generator.gmail_authenticate()
+        self.assertIsNone(creds)
+        # It should have tried to check for token.json then credentials.json
+        self.assertEqual(mock_os_exists.call_count, 2)
+        calls = [unittest.mock.call(report_generator.TOKEN_FILE), unittest.mock.call(report_generator.CREDENTIALS_FILE)]
+        mock_os_exists.assert_has_calls(calls)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sec_parser.py
+++ b/tests/test_sec_parser.py
@@ -1,0 +1,208 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import os
+import xml.etree.ElementTree as ET
+
+# Add project root to sys.path to allow importing project modules
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import sec_parser # Assuming sec_parser.py is in the parent directory
+
+# Sample NPORT-P XML data (simplified for testing)
+SAMPLE_NPORT_P_XML_CONTENT = """
+<edgarSubmission>
+    <formData>
+        <genInfo>
+            <regName>Test Fund Family</regName>
+            <seriesName>Test Fund Series A</seriesName>
+            <totAssets>12345000.00</totAssets>
+        </genInfo>
+        <fundInfo>
+            <!-- More fund info here -->
+        </fundInfo>
+        <invstOrSecs>
+            <invstOrSec>
+                <name>APPLE INC</name>
+                <lei>HWUPKR0MPOU8FGXBT394</lei>
+                <cusip>037833100</cusip>
+                <valUSD>1000000.00</valUSD>
+                <balance>5000</balance>
+                <pctVal>8.10</pctVal>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+                <isRestrictedSec>N</isRestrictedSec>
+                <securityTicker>AAPL</securityTicker>
+            </invstOrSec>
+            <invstOrSec>
+                <name>MICROSOFT CORP</name>
+                <lei>GLEE8Y66F67V82VM2W42</lei>
+                <cusip>594918104</cusip>
+                <valUSD>800000.00</valUSD>
+                <balance>2000</balance>
+                <pctVal>6.48</pctVal>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+                <isRestrictedSec>N</isRestrictedSec>
+                <!-- No ticker for this one -->
+            </invstOrSec>
+        </invstOrSecs>
+    </formData>
+</edgarSubmission>
+"""
+
+SAMPLE_FULL_SUBMISSION_TXT_CONTENT = f"""
+<SEC-DOCUMENT>
+<FILENAME>full-submission.txt
+<TEXT>
+<XML>
+{SAMPLE_NPORT_P_XML_CONTENT}
+</XML>
+</TEXT>
+</SEC-DOCUMENT>
+"""
+
+
+class TestSecParser(unittest.TestCase):
+
+    def setUp(self):
+        # Ensure DOWNLOAD_PATH exists for the downloader instance, even if not used in all tests
+        self.test_download_path = os.path.join(os.getcwd(), "test_sec_filings_parser")
+        if not os.path.exists(self.test_download_path):
+            os.makedirs(self.test_download_path)
+
+        # Patch the Downloader class within sec_parser module
+        self.downloader_patch = patch('sec_parser.Downloader')
+        self.MockDownloaderClass = self.downloader_patch.start()
+        self.mock_downloader_instance = self.MockDownloaderClass.return_value
+
+        # Also patch the global dl instance in sec_parser if it's used directly by functions
+        # If sec_parser.dl is instantiated at module level, we need to patch that specific instance too.
+        # For simplicity, assuming functions might take a downloader instance or use a module global.
+        # If functions always use `sec_parser.dl`, then patch `sec_parser.dl`.
+        # Let's assume sec_parser.dl is the one used.
+        self.dl_instance_patch = patch('sec_parser.dl', self.mock_downloader_instance)
+        self.dl_instance_patch.start()
+
+
+    def tearDown(self):
+        self.downloader_patch.stop()
+        self.dl_instance_patch.stop()
+        if os.path.exists(self.test_download_path):
+            # Clean up created directories, be careful with rmtree
+            for root, dirs, files in os.walk(self.test_download_path, topdown=False):
+                for name in files:
+                    os.remove(os.path.join(root, name))
+                for name in dirs:
+                    os.rmdir(os.path.join(root, name))
+            os.rmdir(self.test_download_path)
+
+
+    @patch('sec_parser.os.path.exists')
+    @patch('sec_parser.os.makedirs')
+    @patch('sec_parser.glob.glob')
+    @patch('builtins.open', new_callable=mock_open) # Mocks open()
+    @patch('xml.etree.ElementTree.parse') # Mocks ET.parse
+    def test_parse_nport_xml_filing_direct_xml(self, mock_et_parse, mock_file_open, mock_glob, mock_makedirs, mock_path_exists):
+        # Simulate finding a direct XML file
+        mock_path_exists.return_value = True # For os.path.exists(DOWNLOAD_PATH)
+        filing_dir = "/fake/path/to/filings/CIK/NPORT-P"
+        accession_dir = os.path.join(filing_dir, "0000123-45-678910")
+        xml_file_path = os.path.join(accession_dir, "formNPORT-P.xml")
+
+        with patch('sec_parser.os.listdir', return_value=["0000123-45-678910"]): # Mock listdir to return accession dir
+            mock_glob.return_value = [xml_file_path] # Simulate glob finding this file
+
+            # Mock the content of the XML file
+            mock_file_open.return_value.read.return_value = SAMPLE_NPORT_P_XML_CONTENT
+
+            # Mock ET.parse to return a mock tree and root
+            mock_tree = MagicMock()
+            mock_root = ET.fromstring(SAMPLE_NPORT_P_XML_CONTENT) # Use real XML for root structure
+            mock_tree.getroot.return_value = mock_root
+            mock_et_parse.return_value = mock_tree
+
+            fund_name, total_assets, holdings = sec_parser.parse_nport_xml_filing(filing_dir)
+
+            self.assertEqual(fund_name, "Test Fund Series A")
+            self.assertEqual(total_assets, 12345000.00)
+            self.assertEqual(len(holdings), 2)
+            self.assertEqual(holdings[0]['name'], "APPLE INC")
+            self.assertEqual(holdings[0]['cusip'], "037833100")
+            self.assertEqual(holdings[0]['ticker'], "AAPL")
+            self.assertEqual(holdings[0]['market_value_usd'], 1000000.00)
+            self.assertEqual(holdings[0]['shares_or_principal_amount'], "5000")
+            self.assertEqual(holdings[0]['percentage_of_fund'], 8.10)
+            self.assertEqual(holdings[1]['name'], "MICROSOFT CORP")
+            self.assertIsNone(holdings[1].get('ticker')) # Ticker is missing for MSFT in sample
+
+    @patch('sec_parser.os.path.exists')
+    @patch('sec_parser.os.makedirs')
+    @patch('sec_parser.glob.glob')
+    @patch('builtins.open', new_callable=mock_open)
+    # No need to mock ET.parse here if we are testing the XML extraction logic primarily
+    def test_parse_nport_xml_filing_from_full_submission_txt(self, mock_file_open, mock_glob, mock_makedirs, mock_path_exists):
+        mock_path_exists.return_value = True
+        filing_dir = "/fake/path/to/filings/CIK/NPORT-P"
+        accession_dir = os.path.join(filing_dir, "0000123-45-678910")
+        txt_file_path = os.path.join(accession_dir, "full-submission.txt")
+
+        with patch('sec_parser.os.listdir', return_value=["0000123-45-678910"]):
+            # This mock_glob should return an empty list for *.xml to force fallback to full-submission.txt
+            # The logic in sec_parser.py tries specific XML names first, then full-submission.txt, then *.xml
+            # So, we need to ensure those specific XML names don't exist (or mock os.path.exists for them)
+            # and that glob for *.xml returns empty.
+
+            # Simulate that preferred XML files (primary_doc.xml, etc.) do not exist
+            def path_exists_side_effect(path):
+                if path == sec_parser.DOWNLOAD_PATH: return True # Initial check for download path
+                if path == filing_dir: return True # Check for filing_dir itself
+                if path == accessions_dir: return True
+                if "full-submission.txt" in path: return True # The .txt file exists
+                if ".xml" in path: return False # No other XML files exist
+                return True # Default for other paths like accession_dir
+
+            mock_path_exists.side_effect = path_exists_side_effect
+            mock_glob.return_value = [] # No other *.xml files found by glob
+
+            # Mock the content of the .txt file when open(txt_file_path) is called
+            mock_file_open.return_value.read.return_value = SAMPLE_FULL_SUBMISSION_TXT_CONTENT
+
+            # The actual ET.fromstring will be called on the extracted XML string
+            fund_name, total_assets, holdings = sec_parser.parse_nport_xml_filing(filing_dir)
+
+            self.assertEqual(fund_name, "Test Fund Series A")
+            self.assertEqual(total_assets, 12345000.00)
+            self.assertEqual(len(holdings), 2)
+            self.assertEqual(holdings[0]['name'], "APPLE INC")
+
+    def test_download_latest_fund_holding_filing_success(self):
+        self.mock_downloader_instance.get.return_value = 1 # Simulate 1 filing downloaded
+        cik = "000TESTCIK"
+        expected_path = os.path.join(sec_parser.DOWNLOAD_PATH, 'sec-edgar-filings', cik, 'NPORT-P')
+
+        # Call the function that uses the mocked downloader
+        result_path = sec_parser.download_latest_fund_holding_filing(cik)
+
+        self.mock_downloader_instance.get.assert_called_with("NPORT-P", cik, limit=1)
+        self.assertEqual(result_path, expected_path)
+
+    def test_download_latest_fund_holding_filing_fallback(self):
+        # Simulate NPORT-P fails, NPORT-EX succeeds
+        self.mock_downloader_instance.get.side_effect = [0, 1]
+        cik = "000FALLBACKCIK"
+        expected_path_nport_ex = os.path.join(sec_parser.DOWNLOAD_PATH, 'sec-edgar-filings', cik, 'NPORT-EX')
+
+        result_path = sec_parser.download_latest_fund_holding_filing(cik)
+
+        self.assertEqual(self.mock_downloader_instance.get.call_count, 2)
+        self.mock_downloader_instance.get.assert_any_call("NPORT-P", cik, limit=1)
+        self.mock_downloader_instance.get.assert_called_with("NPORT-EX", cik, limit=1) # Last call
+        self.assertEqual(result_path, expected_path_nport_ex)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several improvements to the Fund Ownership Analyzer:

1.  **Unit Tests:**
    *   Added an initial suite of unit tests for `sec_parser.py`, `fund_analyzer.py`, and `report_generator.py`.
    *   Utilizes `unittest.mock` to simulate external dependencies (SEC downloader, Alpha Vantage API, Gmail API, file system).
    *   Tests cover core logic such as SEC filing parsing, company ownership calculation, report formatting, and email sending flow.
    *   A `tests/` directory has been created with instructions in README on how to run them.

2.  **Roadmap:**
    *   Created `roadmap.md` outlining potential future enhancements, including:
        *   Improved CIK and CUSIP/ticker resolution.
        *   Support for more SEC filing types (13F, 10-K).
        *   Analysis of registered individual ownership.
        *   Historical data analysis and portfolio overlap.
        *   UI/UX improvements like a web interface and data visualization.

3.  **README Update:**
    *   Significantly updated `README.md` with comprehensive information on:
        *   Project features and description.
        *   Detailed setup instructions, including virtual environment, dependencies.
        *   Step-by-step guidance on obtaining and configuring Alpha Vantage API keys and Gmail API `credentials.json` for OAuth 2.0.
        *   Clear CLI usage examples.
        *   Explanation of the project file structure.
        *   Instructions for running unit tests.
        *   Acknowledgement of current limitations.